### PR TITLE
Edited cubes.py, error correction for specsum axes

### DIFF
--- a/pyspeckit/cubes/cubes.py
+++ b/pyspeckit/cubes/cubes.py
@@ -308,13 +308,13 @@ def extract_aperture(cube, ap, r_mask=False, wcs=None,
 
     npixinmask = mask.sum()
     if method == 'mean':
-        specsum = nansum(cube[:, mask], axis=(1,2))
+        specsum = nansum(cube[:, mask], axis=1)
         spec = specsum / npixinmask
     elif method == 'error':
-        specsum = nansum(cube[:, mask]**2, axis=(1,2))
+        specsum = nansum(cube[:, mask]**2, axis=1)
         spec = (specsum)**0.5 / npixinmask
     else:
-        specsum = nansum(cube[:, mask], axis=(1,2))
+        specsum = nansum(cube[:, mask], axis=1)
 
     if r_mask:
         return spec,mask


### PR DESCRIPTION
Lines 311, 314 and 314:
axis=(1,2) -> axis=1